### PR TITLE
se elimino paquete en conflicto pkg-resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ django-heroku==0.3.1
 django-rest-auth==0.9.5
 djangorestframework==3.10.2
 gunicorn==19.9.0
-pkg-resources==0.0.0
 psycopg2==2.8.3
 python-decouple==3.1
 pytz==2019.2


### PR DESCRIPTION
El paquete es un bug de ubuntu, el cual se encuentra en el requirements.txt y el pipfile.